### PR TITLE
fix: rename hardcoded binary name from lince to zqlz in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Package artifacts
         shell: bash
         run: |
-          BIN=lince
+          BIN=zqlz
           mkdir -p artifacts
 
           if [[ "${{ runner.os }}" == "Windows" ]]; then
@@ -78,7 +78,7 @@ jobs:
       - name: Upload build artifact (temp)
         uses: actions/upload-artifact@v4
         with:
-          name: lince-artifacts-${{ matrix.target }}
+          name: zqlz-artifacts-${{ matrix.target }}
           path: artifacts/*
           if-no-files-found: error
           retention-days: 1


### PR DESCRIPTION
## Problem

The "Package artifacts" step had `BIN=lince` and `name: lince-artifacts-*` hardcoded — a leftover from a previous project. The actual binary produced by `zqlz-app` is named `zqlz`, so the `cp` call failed with *No such file or directory*.

## Fix

- `BIN=lince` → `BIN=zqlz`
- `name: lince-artifacts-*` → `name: zqlz-artifacts-*`