### PR TITLE
chore: bump workspace to 0.0.8 and set GPL license

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,9 +38,9 @@ members = [
 default-members = ["crates/zqlz-app"]
 
 [workspace.package]
-version = "0.0.7"
+version = "0.0.8"
 edition = "2024"
-license = "MIT OR Apache-2.0"
+license = "GPL-3.0-only"
 repository = "https://github.com/yourorg/zqlz"
 publish = false
 


### PR DESCRIPTION
## Summary
- bump workspace package version from `0.0.7` to `0.0.8` in `Cargo.toml`
- update workspace package license from `MIT OR Apache-2.0` to `GPL-3.0-only`
- align release metadata with the tag-gated release workflow (`build-release`) so `v0.0.8` triggers a valid build