### PR TITLE
chore: bump workspace version to 0.0.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11658,7 +11658,7 @@ dependencies = [
 
 [[package]]
 name = "zqlz-admin"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "async-trait",
  "serde",
@@ -11670,7 +11670,7 @@ dependencies = [
 
 [[package]]
 name = "zqlz-analyzer"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "async-trait",
  "pretty_assertions",
@@ -11683,7 +11683,7 @@ dependencies = [
 
 [[package]]
 name = "zqlz-app"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "anyhow",
  "chrono",
@@ -11736,7 +11736,7 @@ dependencies = [
 
 [[package]]
 name = "zqlz-cli"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "anyhow",
  "chrono",
@@ -11755,7 +11755,7 @@ dependencies = [
 
 [[package]]
 name = "zqlz-command-palette"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "gpui",
  "uuid",
@@ -11766,7 +11766,7 @@ dependencies = [
 
 [[package]]
 name = "zqlz-connection"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11787,7 +11787,7 @@ dependencies = [
 
 [[package]]
 name = "zqlz-core"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11805,7 +11805,7 @@ dependencies = [
 
 [[package]]
 name = "zqlz-driver-clickhouse"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "async-trait",
  "chrono",
@@ -11821,7 +11821,7 @@ dependencies = [
 
 [[package]]
 name = "zqlz-driver-duckdb"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "async-trait",
  "chrono",
@@ -11837,7 +11837,7 @@ dependencies = [
 
 [[package]]
 name = "zqlz-driver-mongodb"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "async-trait",
  "bson",
@@ -11854,7 +11854,7 @@ dependencies = [
 
 [[package]]
 name = "zqlz-driver-mssql"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "async-trait",
  "chrono",
@@ -11871,7 +11871,7 @@ dependencies = [
 
 [[package]]
 name = "zqlz-driver-mysql"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11890,7 +11890,7 @@ dependencies = [
 
 [[package]]
 name = "zqlz-driver-postgres"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11912,7 +11912,7 @@ dependencies = [
 
 [[package]]
 name = "zqlz-driver-redis"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11931,7 +11931,7 @@ dependencies = [
 
 [[package]]
 name = "zqlz-driver-sqlite"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "async-trait",
  "chrono",
@@ -11949,7 +11949,7 @@ dependencies = [
 
 [[package]]
 name = "zqlz-driver-turso"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "async-trait",
  "chrono",
@@ -11964,7 +11964,7 @@ dependencies = [
 
 [[package]]
 name = "zqlz-drivers"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11987,7 +11987,7 @@ dependencies = [
 
 [[package]]
 name = "zqlz-explain-visual"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "gpui",
  "serde_json",
@@ -11997,11 +11997,11 @@ dependencies = [
 
 [[package]]
 name = "zqlz-fuzzy"
-version = "0.0.8"
+version = "0.0.9"
 
 [[package]]
 name = "zqlz-interchange"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12024,7 +12024,7 @@ dependencies = [
 
 [[package]]
 name = "zqlz-internal-storage"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "anyhow",
  "rusqlite",
@@ -12033,7 +12033,7 @@ dependencies = [
 
 [[package]]
 name = "zqlz-lsp"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12060,7 +12060,7 @@ dependencies = [
 
 [[package]]
 name = "zqlz-monitor"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "async-trait",
  "chrono",
@@ -12073,7 +12073,7 @@ dependencies = [
 
 [[package]]
 name = "zqlz-objects"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "async-trait",
  "serde",
@@ -12086,7 +12086,7 @@ dependencies = [
 
 [[package]]
 name = "zqlz-query"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12122,7 +12122,7 @@ dependencies = [
 
 [[package]]
 name = "zqlz-schema"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12142,7 +12142,7 @@ dependencies = [
 
 [[package]]
 name = "zqlz-schema-tools"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "async-trait",
  "serde",
@@ -12154,7 +12154,7 @@ dependencies = [
 
 [[package]]
 name = "zqlz-sequence-designer"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "gpui",
  "tracing",
@@ -12204,7 +12204,7 @@ dependencies = [
 
 [[package]]
 name = "zqlz-table-designer"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12223,7 +12223,7 @@ dependencies = [
 
 [[package]]
 name = "zqlz-table-workflows"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -12232,7 +12232,7 @@ dependencies = [
 
 [[package]]
 name = "zqlz-templates"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "anyhow",
  "chrono",
@@ -12245,7 +12245,7 @@ dependencies = [
 
 [[package]]
 name = "zqlz-text-editor"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "anyhow",
  "chrono",
@@ -12273,7 +12273,7 @@ dependencies = [
 
 [[package]]
 name = "zqlz-trigger-designer"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12292,7 +12292,7 @@ dependencies = [
 
 [[package]]
 name = "zqlz-ui"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -12338,7 +12338,7 @@ dependencies = [
 
 [[package]]
 name = "zqlz-versioning"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ members = [
 default-members = ["crates/zqlz-app"]
 
 [workspace.package]
-version = "0.0.8"
+version = "0.0.9"
 edition = "2024"
 license = "GPL-3.0-or-later"
 repository = "https://github.com/yourorg/zqlz"


### PR DESCRIPTION
## Summary
- Bumps the workspace package version from 0.0.8 to 0.0.9 using `./script/bump-version patch`.
- Updates Cargo.lock package entries for workspace crates.

## Tests
- `cargo check --workspace --all-targets` started and progressed through workspace checks, but timed out after 120s in the tool runner.